### PR TITLE
Ensure spaces around span tag

### DIFF
--- a/layouts/shortcodes/cloakemail.html
+++ b/layouts/shortcodes/cloakemail.html
@@ -15,7 +15,7 @@
     direction:rtl;
   }
 </style>
-<span class="cloaked-e-mail" data-user="{{ range $index := seq (sub (len $user) 1) 0}}{{ substr $user $index 1}}{{ end }}" data-domain="{{ range $index := seq (sub (len $domain) 1) 0}}{{ substr $domain $index 1}}{{ end }}"></span>
+&#32;<span class="cloaked-e-mail" data-user="{{ range $index := seq (sub (len $user) 1) 0}}{{ substr $user $index 1}}{{ end }}" data-domain="{{ range $index := seq (sub (len $domain) 1) 0}}{{ substr $domain $index 1}}{{ end }}"></span>&#32;
 <script id="{{ $fingerprint }}">
   var scriptTag = document.getElementById("{{ $fingerprint }}");
   var link = document.createElement("a");


### PR DESCRIPTION
I noticed the span tag was sometimes causing surrounding text to touch it, so this ensures there's a space on either side.