### PR TITLE
Make shortcode also usable as partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 ## About
 
-This [Hugo](https://gohugo.io) theme component provides a shortcode.
+This [Hugo](https://gohugo.io) theme component provides a shortcode and a partial
 
 ## Features
 
-Shortcode `cloakemail` cloakes e-mail or other messaging (`xmpp`, `tg`, etc.) or phone (`sip`, `tel`, etc.) addresses from spamming bots.
+Shortcode `cloakemail` cloakes e-mail or other messaging (`xmpp`, `tg`, etc.) or phone (`sip`, `tel`, etc.) addresses from spamming bots. Can also be used as a partial with equivalent functionality.
 
 ### Mandatory parameter
 
@@ -30,6 +30,15 @@ Don't indicate other URI parameters, for instance to indicate an e-mail subject.
 - Use `query` to specify a e-mail subject or other URI parameters (URI query): `{{< cloakemail address="jane.doe@example.com" query="subject=Message from contact form" >}}`. The query is never printed on the web page.
 
 All parameters can be combined.
+
+### Use as partial
+
+In some cases, you have to embed e-mail addresses directly in your theme code, e.g. partials. Therefore, you can also use the functionality as a partial.
+
+Examples:
+
+- `{{ partial "cloakemail" (dict "address" "jane.doe@example.com") }}`
+- `{{ partial "cloakemail" (dict "address" "jane.doe@example.com" "protocol" "xmpp") }}`
 
 ### How it works
 

--- a/layouts/partials/cloakemail.html
+++ b/layouts/partials/cloakemail.html
@@ -1,0 +1,38 @@
+{{/* Get address, protocol and other parameters */}}
+{{- $address := .address -}}
+{{- $protocol := .protocol | default "mailto" -}}
+{{- $class := .class -}}
+{{- $displaytext := .display -}}
+{{- $parts := split $address "@" -}}
+{{- $user := (index $parts 0) -}}
+{{- $domain := (index $parts 1) | default "" -}}
+{{- $query := .query | default "" -}}
+{{/* Compute md5 fingerprint */}}
+{{- $fingerprint := md5 (print $address $protocol (index (seq 999 | shuffle) 0)) | truncate 8 "" -}}
+{{/* Set via CSS what is displayed when Javascript is disabled. Query is never displayed */}}
+<style>
+  #span-{{ $fingerprint }}.cloaked-e-mail:before {
+    content:{{ with $domain }}attr(data-domain) "\0040" {{ end }}attr(data-user);
+    unicode-bidi:bidi-override;
+    direction:rtl;
+  }
+</style>
+&#32;<span class="cloaked-e-mail" data-user="{{ range $index := seq (sub (len $user) 1) 0}}{{ substr $user $index 1}}{{ end }}"{{ with $domain }} data-domain="{{ range $index := seq (sub (len $domain) 1) 0}}{{ substr $domain $index 1}}{{ end }}"{{ end }} id="span-{{ $fingerprint }}"></span>&#32;
+{{/* Alter display with Javascript by changing DOM */}}
+<script id="script-{{ $fingerprint }}">
+  var scriptTag = document.getElementById("script-{{ $fingerprint }}");
+  var link = document.createElement("a");
+  var address = "{{ range $index := seq (sub (len $user) 1) 0}}{{ substr $user $index 1}}{{ end }}".split('').reverse().join(''){{ with $domain }} + "@" + "{{ range $index := seq (sub (len $domain) 1) 0}}{{ substr $domain $index 1}}{{ end }}".split('').reverse().join(''){{ with $query }} + "?" + "{{ range $index := seq (sub (len $query) 1) 0}}{{ substr $query $index 1}}{{ end }}".split('').reverse().join(''){{ end }}{{ end }};
+  link.href = {{ $protocol }} + ":" + address;
+  {{- with $displaytext }}
+  link.innerText = {{ $displaytext }};
+  {{- else }}
+  link.innerText = address.split('?')[0];
+  {{- end }}
+  {{- with $class }}
+  link.className = "{{ $class }}";
+  {{- end }}
+  scriptTag.parentElement.insertBefore(link, scriptTag.previousElementSibling);
+  scriptTag.parentElement.removeChild(scriptTag.previousElementSibling)
+</script>
+{{/* The end */}}

--- a/layouts/shortcodes/cloakemail.html
+++ b/layouts/shortcodes/cloakemail.html
@@ -1,38 +1,10 @@
-{{/* Get address, protocol and other parameters */}}
-{{- $address := .Get "address" | default (.Get 0) -}}
-{{- $protocol := .Get "protocol" | default "mailto" -}}
-{{- $class := .Get "class" -}}
-{{- $displaytext := .Get "display" -}}
-{{- $parts := split $address "@" -}}
-{{- $user := (index $parts 0) -}}
-{{- $domain := (index $parts 1) | default "" -}}
-{{- $query := .Get "query" | default "" -}}
-{{/* Compute md5 fingerprint */}}
-{{- $fingerprint := md5 (print $address $protocol (index (seq 999 | shuffle) 0)) | truncate 8 "" -}}
-{{/* Set via CSS what is displayed when Javascript is disabled. Query is never displayed */}}
-<style>
-  #span-{{ $fingerprint }}.cloaked-e-mail:before {
-    content:{{ with $domain }}attr(data-domain) "\0040" {{ end }}attr(data-user);
-    unicode-bidi:bidi-override;
-    direction:rtl;
-  }
-</style>
-&#32;<span class="cloaked-e-mail" data-user="{{ range $index := seq (sub (len $user) 1) 0}}{{ substr $user $index 1}}{{ end }}"{{ with $domain }} data-domain="{{ range $index := seq (sub (len $domain) 1) 0}}{{ substr $domain $index 1}}{{ end }}"{{ end }} id="span-{{ $fingerprint }}"></span>&#32;
-{{/* Alter display with Javascript by changing DOM */}}
-<script id="script-{{ $fingerprint }}">
-  var scriptTag = document.getElementById("script-{{ $fingerprint }}");
-  var link = document.createElement("a");
-  var address = "{{ range $index := seq (sub (len $user) 1) 0}}{{ substr $user $index 1}}{{ end }}".split('').reverse().join(''){{ with $domain }} + "@" + "{{ range $index := seq (sub (len $domain) 1) 0}}{{ substr $domain $index 1}}{{ end }}".split('').reverse().join(''){{ with $query }} + "?" + "{{ range $index := seq (sub (len $query) 1) 0}}{{ substr $query $index 1}}{{ end }}".split('').reverse().join(''){{ end }}{{ end }};
-  link.href = {{ $protocol }} + ":" + address;
-  {{- with $displaytext }}
-  link.innerText = {{ $displaytext }};
-  {{- else }}
-  link.innerText = address.split('?')[0];
-  {{- end }}
-  {{- with $class }}
-  link.className = "{{ $class }}";
-  {{- end }}
-  scriptTag.parentElement.insertBefore(link, scriptTag.previousElementSibling);
-  scriptTag.parentElement.removeChild(scriptTag.previousElementSibling)
-</script>
-{{/* The end */}}
+
+{{- partial "cloakemail.html"
+  (dict
+    "address" (.Get "address" | default (.Get 0))
+    "protocol" (.Get "protocol")
+    "class" (.Get "class")
+    "display" (.Get "display")
+    "query" (.Get "query")
+  )
+-}}


### PR DESCRIPTION
In a current use-case, I had to embed an email in a Hugo partial directly. Unfortunately, [you cannot call shortcodes from partials](https://discourse.gohugo.io/t/can-i-call-a-shortcode-from-a-partial/39043/1).

Therefore, I put the main logic into a partial and made the shortcode call the partial. This way, we also avoid duplicated code.

The shortcode can be used as before, but please feel free to review carefully and test.